### PR TITLE
use dev version of ghit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,5 +17,7 @@ Imports:
     jsonlite,
     stringr,
     utils
+Remotes:
+    cloudyr/ghit
 RoxygenNote: 5.0.1
 Suggests: testthat


### PR DESCRIPTION
For now, it is better to specify `cloudyr/ghit` in DESCRIPTION. This fixes #1.