### PR TITLE
Canonical CRAN.R-project.org URLs use https

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: githubinstall
 Type: Package
-Version: 0.2.0
+Version: 0.2.1
 Title: A Helpful Way to Install R Packages Hosted on GitHub
 Description: Provides an helpful way to install packages hosted on GitHub.
 Authors@R: c(

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 ```
 
 [![Travis-CI Build Status](https://travis-ci.org/hoxo-m/githubinstall.svg?branch=master)](https://travis-ci.org/hoxo-m/githubinstall)
-[![CRAN Version](http://www.r-pkg.org/badges/version/githubinstall)](http://cran.rstudio.com/web/packages/githubinstall)
+[![CRAN Version](http://www.r-pkg.org/badges/version/githubinstall)](https://cran.r-project.org/package=githubinstall)
 [![CRAN Downloads](http://cranlogs.r-pkg.org/badges/githubinstall)](http://cranlogs.r-pkg.org/badges/githubinstall)
 [![Coverage Status](https://coveralls.io/repos/github/hoxo-m/githubinstall/badge.svg?branch=master)](https://coveralls.io/github/hoxo-m/githubinstall?branch=master)
 
@@ -310,8 +310,8 @@ gh_update_package_list()
 
 ## 4. Related Work
 
-- devtools: [Tools to make an R developer's life easier](https://github.com/hadley/devtools) [![CRAN Version](http://www.r-pkg.org/badges/version/devtools)](http://cran.rstudio.com/web/packages/devtools) 
-- ghit: [Lightweight GitHub Package Installer](https://github.com/cloudyr/ghit) [![CRAN Version](http://www.r-pkg.org/badges/version/ghit)](http://cran.rstudio.com/web/packages/ghit)
-- drat: [Drat R Archive Template](https://github.com/eddelbuettel/drat) [![CRAN Version](http://www.r-pkg.org/badges/version/drat)](http://cran.rstudio.com/web/packages/drat)
-- pacman: [A package management tools for R](https://github.com/trinker/pacman) [![CRAN Version](http://www.r-pkg.org/badges/version/pacman)](http://cran.rstudio.com/web/packages/pacman)
-- remotes: [Install R packages from GitHub, Bitbucket, git, svn repositories, URLs](https://github.com/MangoTheCat/remotes) [![CRAN Version](http://www.r-pkg.org/badges/version/remotes)](http://cran.rstudio.com/web/remotes)
+- devtools: [Tools to make an R developer's life easier](https://github.com/hadley/devtools) [![CRAN Version](http://www.r-pkg.org/badges/version/devtools)](https://cran.r-project.org/package=devtools) 
+- ghit: [Lightweight GitHub Package Installer](https://github.com/cloudyr/ghit) [![CRAN Version](http://www.r-pkg.org/badges/version/ghit)](https://cran.r-project.org/package=ghit)
+- drat: [Drat R Archive Template](https://github.com/eddelbuettel/drat) [![CRAN Version](http://www.r-pkg.org/badges/version/drat)](https://cran.r-project.org/package=drat)
+- pacman: [A package management tools for R](https://github.com/trinker/pacman) [![CRAN Version](http://www.r-pkg.org/badges/version/pacman)](https://cran.r-project.org/package=pacman)
+- remotes: [Install R packages from GitHub, Bitbucket, git, svn repositories, URLs](https://github.com/MangoTheCat/remotes) [![CRAN Version](http://www.r-pkg.org/badges/version/remotes)](https://cran.r-project.org/package=remotes)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Koji MAKIYAMA (@hoxo_m)
 
 
 [![Travis-CI Build Status](https://travis-ci.org/hoxo-m/githubinstall.svg?branch=master)](https://travis-ci.org/hoxo-m/githubinstall)
-[![CRAN Version](http://www.r-pkg.org/badges/version/githubinstall)](http://cran.rstudio.com/web/packages/githubinstall)
+[![CRAN Version](http://www.r-pkg.org/badges/version/githubinstall)](https://cran.r-project.org/package=githubinstall)
 [![CRAN Downloads](http://cranlogs.r-pkg.org/badges/githubinstall)](http://cranlogs.r-pkg.org/badges/githubinstall)
 [![Coverage Status](https://coveralls.io/repos/github/hoxo-m/githubinstall/badge.svg?branch=master)](https://coveralls.io/github/hoxo-m/githubinstall?branch=master)
 
@@ -349,8 +349,8 @@ gh_update_package_list()
 
 ## 4. Related Work
 
-- devtools: [Tools to make an R developer's life easier](https://github.com/hadley/devtools) [![CRAN Version](http://www.r-pkg.org/badges/version/devtools)](http://cran.rstudio.com/web/packages/devtools) 
-- ghit: [Lightweight GitHub Package Installer](https://github.com/cloudyr/ghit) [![CRAN Version](http://www.r-pkg.org/badges/version/ghit)](http://cran.rstudio.com/web/packages/ghit)
-- drat: [Drat R Archive Template](https://github.com/eddelbuettel/drat) [![CRAN Version](http://www.r-pkg.org/badges/version/drat)](http://cran.rstudio.com/web/packages/drat)
-- pacman: [A package management tools for R](https://github.com/trinker/pacman) [![CRAN Version](http://www.r-pkg.org/badges/version/pacman)](http://cran.rstudio.com/web/packages/pacman)
-- remotes: [Install R packages from GitHub, Bitbucket, git, svn repositories, URLs](https://github.com/MangoTheCat/remotes) [![CRAN Version](http://www.r-pkg.org/badges/version/remotes)](http://cran.rstudio.com/web/remotes)
+- devtools: [Tools to make an R developer's life easier](https://github.com/hadley/devtools) [![CRAN Version](http://www.r-pkg.org/badges/version/devtools)](https://cran.r-project.org/package=devtools) 
+- ghit: [Lightweight GitHub Package Installer](https://github.com/cloudyr/ghit) [![CRAN Version](http://www.r-pkg.org/badges/version/ghit)](https://cran.r-project.org/package=ghit)
+- drat: [Drat R Archive Template](https://github.com/eddelbuettel/drat) [![CRAN Version](http://www.r-pkg.org/badges/version/drat)](https://cran.r-project.org/package=drat)
+- pacman: [A package management tools for R](https://github.com/trinker/pacman) [![CRAN Version](http://www.r-pkg.org/badges/version/pacman)](https://cran.r-project.org/package=pacman)
+- remotes: [Install R packages from GitHub, Bitbucket, git, svn repositories, URLs](https://github.com/MangoTheCat/remotes) [![CRAN Version](http://www.r-pkg.org/badges/version/remotes)](https://cran.r-project.org/package=remotes)


### PR DESCRIPTION
Found the following (possibly) invalid URLs:
  URL: http://cran.rstudio.com/web/packages/devtools (moved to https://cran.rstudio.com/web/packages/devtools/)
    From: README.md
    Status: 200
    Message: OK
    CRAN URL not in canonical form
  URL: http://cran.rstudio.com/web/packages/drat (moved to https://cran.rstudio.com/web/packages/drat/)
    From: README.md
    Status: 200
    Message: OK
    CRAN URL not in canonical form
  URL: http://cran.rstudio.com/web/packages/ghit (moved to https://cran.rstudio.com/web/packages/ghit/)
    From: README.md
    Status: 200
    Message: OK
    CRAN URL not in canonical form
  URL: http://cran.rstudio.com/web/packages/githubinstall (moved to https://cran.rstudio.com/web/packages/githubinstall/)
    From: README.md
    Status: 200
    Message: OK
    CRAN URL not in canonical form
  URL: http://cran.rstudio.com/web/packages/pacman (moved to https://cran.rstudio.com/web/packages/pacman/)
    From: README.md
    Status: 200
    Message: OK
    CRAN URL not in canonical form
  URL: http://cran.rstudio.com/web/remotes (moved to https://cran.rstudio.com/web/remotes)
    From: README.md
    Status: 404
    Message: Not Found
    CRAN URL not in canonical form
  Canonical CRAN.R-project.org URLs use https.