### PR TITLE
use mockery::stub instead of testthat::mock_with for CRAN check error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: githubinstall
 Type: Package
-Version: 0.2.1.9001
+Version: 0.2.1.9002
 Title: A Helpful Way to Install R Packages Hosted on GitHub
 Description: Provides an helpful way to install packages hosted on GitHub.
 Authors@R: c(
@@ -19,8 +19,10 @@ Imports:
     devtools,
     httr,
     jsonlite,
+    mockery,
     utils
 RoxygenNote: 5.0.1
+Encoding: UTF-8
 Suggests:
     testthat,
     ggplot2, 

--- a/tests/testthat/test-gh_install_packages.R
+++ b/tests/testthat/test-gh_install_packages.R
@@ -6,39 +6,31 @@ install_package_mock <- function(...) {
 
 test_that("Install a single package", {
   repo <- "AnomalyDetection"
-  with_mock(
-    `githubinstall:::install_package` = install_package_mock, 
-    act <- gh_install_packages(repo, ask = FALSE)
-  )
+  mockery::stub(gh_install_packages, "install_package", install_package_mock)
+  act <- gh_install_packages(repo, ask = FALSE)
   expect_equal(act$repo, "twitter/AnomalyDetection")
 })
 
 test_that("Install two package", {
   repo <- c("AnomalyDetection", "toybayesopt")
-  with_mock(
-    `githubinstall:::install_package` = install_package_mock, 
-    act <- gh_install_packages(repo, ask = FALSE)
-  )
+  mockery::stub(gh_install_packages, "install_package", install_package_mock)
+  act <- gh_install_packages(repo, ask = FALSE)
   expect_equal(length(act), 2)
 })
 
 test_that("Install: ask no", {
   repo <- c("AnomalyDetection")
-  with_mock(
-    `base::readline` = function(...) "No",
-    expect_error(
-      gh_install_packages(repo, ask = TRUE)
-    )
+  mockery::stub(gh_install_packages, "readline", "N")
+  expect_error(
+    gh_install_packages(repo, ask = TRUE)
   )
 })
 
 test_that("Install: ask yes", {
   repo <- c("AnomalyDetection")
-  with_mock(
-    `base::readline` = function(...) "Y",
-    `githubinstall:::install_package` = install_package_mock,
-    act <- gh_install_packages(repo, ask = TRUE)
-  )
+  mockery::stub(gh_install_packages, "readline", "Y")
+  mockery::stub(gh_install_packages, "install_package", install_package_mock)
+  act <- gh_install_packages(repo, ask = TRUE)
   expect_equal(act$repo, "twitter/AnomalyDetection")
 })
 

--- a/tests/testthat/test-utils_for_install.R
+++ b/tests/testthat/test-utils_for_install.R
@@ -46,11 +46,10 @@ test_that("recommend_dependencies: ask = TRUE", {
   quiet <- FALSE
   
   is_passed_mock <- FALSE
-  with_mock(
-    `base::readline` = function(...) { is_passed_mock <<- TRUE; "y" },
-    act <- recommend_dependencies(ask = ask, build_vignettes = build_vignettes, 
-                                  dependencies = dependencies, quiet = quiet)
-  )
+  mockery::stub(recommend_dependencies, "readline", function(...) { is_passed_mock <<- TRUE; "y" })
+  act <- recommend_dependencies(ask = ask, build_vignettes = build_vignettes, 
+                                dependencies = dependencies, quiet = quiet)
+  
   expect_true(is_passed_mock)
   expect_equal(act, TRUE)
 })
@@ -127,10 +126,8 @@ test_that("select_repository: single candidate", {
 test_that("select_repository: multi candidates", {
   package_name <- "cats"
   
-  with_mock(
-    `utils::menu` = function(...) 1,
-    act <- select_repository(package_name = package_name)
-  )
+  mockery::stub(select_repository, "menu", 1)
+  act <- select_repository(package_name = package_name)
   
   expect_equal(strsplit(act, "/")[[1]][2], "cats")
   expect_false(is.null(attr(act, "title")))
@@ -139,11 +136,9 @@ test_that("select_repository: multi candidates", {
 test_that("select_repository: cancel", {
   package_name <- "cats"
   
-  with_mock(
-    `utils::menu` = function(...) 0,
-    expect_error(
-      select_repository(package_name = package_name)
-    )
+  mockery::stub(select_repository, "menu", 0)
+  expect_error(
+    select_repository(package_name = package_name)
   )
 })
 
@@ -166,10 +161,8 @@ test_that("remove_conflict_repos: no installed", {
   quiet = FALSE
   ask = TRUE
   
-  with_mock(
-    `utils::packageDescription` = function(pkg, ...) NA,
-    act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
-  ) 
+  mockery::stub(remove_conflict_repos, "packageDescription", NA)
+  act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
   
   expect_equal(act, repos)
 })
@@ -180,11 +173,10 @@ test_that("remove_conflict_repos: not conflict", {
   quiet = FALSE
   ask = TRUE
 
-  with_mock(
-    `utils::packageDescription` = function(pkg, ...) list(Package = pkg, GithubRepo = pkg, GithubUsername = "johndoe"),
-    `base::readline` = stop,
-    act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
-  ) 
+  mockery::stub(remove_conflict_repos, "packageDescription", 
+                function(pkg, ...) list(Package = pkg, GithubRepo = pkg, GithubUsername = "johndoe"))
+  mockery::stub(remove_conflict_repos, "readline", stop)
+  act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
   
   expect_equal(act, repos)
 })
@@ -195,11 +187,10 @@ test_that("remove_conflict_repos: conflict GitHub, ask yes", {
   quiet = FALSE
   ask = TRUE
   
-  with_mock(
-    `utils::packageDescription` = function(pkg, ...) list(Package = pkg, GithubRepo = pkg, GithubUsername = "ANOther"),
-    `base::readline` = function(...) "y",
-    act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
-  ) 
+  mockery::stub(remove_conflict_repos, "packageDescription", 
+                function(pkg, ...) list(Package = pkg, GithubRepo = pkg, GithubUsername = "ANOther"))
+  mockery::stub(remove_conflict_repos, "readline", "y")
+  act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
   
   expect_equal(act, repos)
 })
@@ -210,11 +201,10 @@ test_that("remove_conflict_repos: conflict GitHub, ask no", {
   quiet = FALSE
   ask = TRUE
   
-  with_mock(
-    `utils::packageDescription` = function(pkg, ...) list(Package = pkg, GithubRepo = pkg, GithubUsername = "ANOther"),
-    `base::readline` = function(...) "n",
-    act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
-  ) 
+  mockery::stub(remove_conflict_repos, "packageDescription", 
+                function(pkg, ...) list(Package = pkg, GithubRepo = pkg, GithubUsername = "ANOther"))
+  mockery::stub(remove_conflict_repos, "readline", "n")
+  act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
   
   expect_equal(length(act), 0)
 })
@@ -225,11 +215,10 @@ test_that("remove_conflict_repos: conflict CRAN, ask yes", {
   quiet = FALSE
   ask = TRUE
   
-  with_mock(
-    `utils::packageDescription` = function(pkg, ...) list(Package = pkg, Repository = "CRAN"),
-    `base::readline` = function(...) "y",
-    act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
-  ) 
+  mockery::stub(remove_conflict_repos, "packageDescription", 
+                function(pkg, ...) list(Package = pkg, Repository = "CRAN"))
+  mockery::stub(remove_conflict_repos, "readline", "y")
+  act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
   
   expect_equal(act, repos)
 })
@@ -240,11 +229,10 @@ test_that("remove_conflict_repos: conflict CRAN, ask no", {
   quiet = FALSE
   ask = TRUE
   
-  with_mock(
-    `utils::packageDescription` = function(pkg, ...) list(Package = pkg, Repository = "CRAN"),
-    `base::readline` = function(...) "n",
-    act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
-  ) 
+  mockery::stub(remove_conflict_repos, "packageDescription", 
+                function(pkg, ...) list(Package = pkg, Repository = "CRAN"))
+  mockery::stub(remove_conflict_repos, "readline", "n")
+  act <- remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
   
   expect_equal(length(act), 0)
 })
@@ -255,11 +243,10 @@ test_that("remove_conflict_repos: conflict, ask == FALSE", {
   quiet = FALSE
   ask = FALSE
   
-  with_mock(
-    `utils::packageDescription` = function(pkg, ...) list(Package = pkg, Repository = "CRAN"),
-    `base::readline` = stop,
-    expect_message(
-      remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
-    )
-  ) 
+  mockery::stub(remove_conflict_repos, "packageDescription", 
+                function(pkg, ...) list(Package = pkg, Repository = "CRAN"))
+  mockery::stub(remove_conflict_repos, "readline", stop)
+  expect_message(
+    remove_conflict_repos(repos = repos, lib = lib, quiet = quiet, ask = ask)
+  )
 })


### PR DESCRIPTION
use `mockery::stub` instead of `testthat::mock_with` for CRAN check error

`testthat::mock_with` has been deprecated.